### PR TITLE
Add replay (catch up) functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ courage.bind('791f011e-7d16-4614-9e2f-1b28db45b7b3', function(data) {
 
 The above code decodes the binary data into a UTF-8 string, and parses a JSON object from it.
 
+You may optionally pass an `options` object as a third argument to bind, to specify if undelivered messages should be replayed:
+
+```js
+{
+  replay: true,
+}
+```
+
+By default, undelivered messages are not replayed and are therefore discarded by the service.
 
 ### Requirements
 


### PR DESCRIPTION
This pull request allows you to pass an optional map of options to `bind`, currently only used to set `replay`.
